### PR TITLE
[Dashboards] Add support for automountServiceAccountToken

### DIFF
--- a/charts/opensearch-dashboards/CHANGELOG.md
+++ b/charts/opensearch-dashboards/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Support for disabling automountServiceAccountToken
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch-dashboards/Chart.yaml
+++ b/charts/opensearch-dashboards/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opensearch-dashboards/templates/serviceaccount.yaml
+++ b/charts/opensearch-dashboards/templates/serviceaccount.yaml
@@ -10,3 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccount.automountServiceAccountToken }}
+{{- else }}
+automountServiceAccountToken: false
+{{- end -}}

--- a/charts/opensearch-dashboards/values.yaml
+++ b/charts/opensearch-dashboards/values.yaml
@@ -53,6 +53,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Controls whether the ServiceAccount API token is automatically mounted on pod
+  automountServiceAccountToken: true
 
 rbac:
   create: true


### PR DESCRIPTION
### Description
_[Describe what this change achieves.]_
This change adds the ability to disable the automatic mounting of the serviceAccount API token to the OpenSearch
Dashboards pod.  The current behavior of auto-mounting the token is maintained; however, the chart now allows
this behavior to be changed by setting the serviceAccount.automountServiceAccountToken key to 'false'.  The OpenSearch
Helm chart already supports this and disabling this behavior is considered a security best practice.
 
### Issues Resolved
_[List any issues this PR will resolve. You should likely open an issue if one does not already exist.]_
A Proposal/Feature Request will be opened
 
### Check List
- [x] Commits are signed per the DCO using --signoff

For any changes to files within Helm chart directories:
- [x] Helm chart version bumped
- [x] Helm chart `CHANGELOG.md` updated to reflect change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/helm-charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
